### PR TITLE
www-client/chromium: Fix gn args for system-allocator USE flag

### DIFF
--- a/www-client/chromium/chromium-110.0.5481.100.ebuild
+++ b/www-client/chromium/chromium-110.0.5481.100.ebuild
@@ -776,6 +776,8 @@ chromium_configure() {
 	if use system-allocator; then
 		myconf_gn+=" use_allocator=\"none\""
 		myconf_gn+=" use_allocator_shim=false"
+		myconf_gn+=" use_partition_alloc_as_malloc=false"
+		myconf_gn+=" enable_backup_ref_ptr_support=false"
 	fi
 
 	# Disable nacl, we can't build without pnacl (http://crbug.com/269560).


### PR DESCRIPTION
Currently, chromium fails to build with the `system-allocator` USE flag due to an assert failure in the build script:
```
ERROR at //base/allocator/BUILD.gn:14:3: Assertion failed.
  assert(use_allocator_shim || !use_partition_alloc_as_malloc,
  ^-----
```

Adding `myconf_gn+=" use_partition_alloc_as_malloc=false"` still doesn't work, this time the build failing somewhere else:
```
ERROR at //base/allocator/allocator.gni:40:3: Assertion failed.
  assert(!enable_backup_ref_ptr_support,
  ^-----
```

This, however, seems to be the last thing needed to be fixed.
Adding `myconf_gn+=" enable_backup_ref_ptr_support=false"` is enough to make it work again, for my setup at least.

