### PR TITLE
sys-libs/compiler-rt: add fixes for wasm32-wasi to 18.x

### DIFF
--- a/sys-libs/compiler-rt/compiler-rt-18.1.8-r1.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-18.1.8-r1.ebuild
@@ -33,6 +33,12 @@ BDEPEND="
 LLVM_COMPONENTS=( compiler-rt cmake llvm/cmake )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/"0001-normalize-compiler-rt-default-target-triple.patch
+	"${FILESDIR}/"0002-fix-cmake-configure-on-windows.patch
+	"${FILESDIR}/"0003-use-clang-to-infer-the-target-triple.patch
+)
+
 python_check_deps() {
 	use test || return 0
 	python_has_version ">=dev-python/lit-15[${PYTHON_USEDEP}]"

--- a/sys-libs/compiler-rt/files/0001-normalize-compiler-rt-default-target-triple.patch
+++ b/sys-libs/compiler-rt/files/0001-normalize-compiler-rt-default-target-triple.patch
@@ -1,0 +1,68 @@
+From d3925e65a7ab88eb0ba68d3ab79cd95db5629951 Mon Sep 17 00:00:00 2001
+From: YunQiang Su <syq@debian.org>
+Date: Fri, 19 Apr 2024 11:19:36 +0800
+Subject: [PATCH] CompilerRT: Normalize COMPILER_RT_DEFAULT_TARGET_TRIPLE
+ (#89234)
+
+If LLVM is configured with -DLLVM_DEFAULT_TARGET_TRIPLE, or compiler_rt
+is configured with -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE, while the
+argument is not normalized, such as Debian-style vendor-less triple,
+clang will try to find libclang_rt in lib/<normalized_triple>, while
+libclang_rt is placed into lib/<triple_arg>.
+
+Let's also place libclang_rt into lib/<normalized_triple>.
+`libcxx/utils/ci/run-buildbot` is also updated to use
+`armv7m-none-unknown-eabi` as normalized triple instead of
+current `armv7m-none-eabi`.
+
+ChangeLog of this PR:
+This patch has been applied and revert twice:
+1. The first try is https://github.com/llvm/llvm-project/pull/88407, and
+then it is found that it causes some CI failures.
+    https://lab.llvm.org/buildbot/#/builders/98/builds/36366
+It is then resolved by another commit:
+https://github.com/llvm/llvm-project/commit/1693009679313282afbed38778dd3fad62641e1b
+
+    https://lab.llvm.org/buildbot/#/builders/77/builds/36372
+It is caused that `COMPILER_RT_DEFAULT_TARGET_TRIPLE` is overwrite
+without taking care about `CACHE`.
+
+2. The second try https://github.com/llvm/llvm-project/pull/88835,
+     resolves https://lab.llvm.org/buildbot/#/builders/77/builds/36372
+     and in fact only one `execute_process` is needed.
+
+Then we find some other CI failures.
+https://github.com/mstorsjo/llvm-mingw/actions/runs/8730621159
+
+https://buildkite.com/llvm-project/libcxx-ci/builds/34897#018eec06-612c-47f1-9931-d3bd88bf7ced
+
+It is due to misunderstanding `-print-effective-triple`: which will
+output `thumbv7-w64-windows-gnu` for `armv7-w64-windows-gnu` or some
+other thumb-enabled arm triples.
+In fact we should use `-print-target-triple`.
+
+For armv7m-picolibc, `armv7m-none-eabi` is hardcoded in
+libcxx/utils/ci/run-buildbot, while in fact `armv7m-none-unknown-eabi`
+is the real normalized triple.
+---
+ compiler-rt/cmake/Modules/CompilerRTUtils.cmake | 6 ++++++
+ libcxx/utils/ci/run-buildbot                    | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+index e8e5f612d5b03c..a6c6ef93500d53 100644
+--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
++++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+@@ -368,6 +368,12 @@ macro(construct_compiler_rt_default_triple)
+           "Default triple for which compiler-rt runtimes will be built.")
+   endif()
+ 
++  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
++    execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-target-triple
++                    OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
++                    OUTPUT_STRIP_TRAILING_WHITESPACE)
++  endif()
++
+   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})
+   list(GET LLVM_TARGET_TRIPLE_LIST 0 COMPILER_RT_DEFAULT_TARGET_ARCH)
+ 

--- a/sys-libs/compiler-rt/files/0002-fix-cmake-configure-on-windows.patch
+++ b/sys-libs/compiler-rt/files/0002-fix-cmake-configure-on-windows.patch
@@ -1,0 +1,35 @@
+From 33e16cae671ca10d88e198192181220f8adff343 Mon Sep 17 00:00:00 2001
+From: Omair Javaid <omair.javaid@linaro.org>
+Date: Thu, 2 May 2024 18:27:23 +0500
+Subject: [PATCH] [compiler-rt] Fix CMake configure on Windows (#90843)
+
+CMake configure compiler-rt got broken as a result of following commit:
+d3925e65a7ab88eb0ba68d3ab79cd95db5629951
+
+This patch fixes the break by porting the above commit for clang-cl.
+
+This problem was not caught on Windows buildbots beacuase it appeared
+when compiler-rt was included via LLVM_ENABLE_PROJECTS while buildbots
+include compiler-rt project using LLVM_ENABLE_RUNTIMES flag.
+---
+ compiler-rt/cmake/Modules/CompilerRTUtils.cmake | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+index a6c6ef93500d53..8e331634b76bd0 100644
+--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
++++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+@@ -369,7 +369,11 @@ macro(construct_compiler_rt_default_triple)
+   endif()
+ 
+   if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+-    execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-target-triple
++    set(option_prefix "")
++    if (CMAKE_C_SIMULATE_ID MATCHES "MSVC")
++      set(option_prefix "/clang:")
++    endif()
++    execute_process(COMMAND ${CMAKE_C_COMPILER} ${option_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple
+                     OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+   endif()
+

--- a/sys-libs/compiler-rt/files/0003-use-clang-to-infer-the-target-triple.patch
+++ b/sys-libs/compiler-rt/files/0003-use-clang-to-infer-the-target-triple.patch
@@ -1,0 +1,48 @@
+From 9cb9a97e44130e17e96f994c3e594aba69ea1ad5 Mon Sep 17 00:00:00 2001
+From: Petr Hosek <phosek@google.com>
+Date: Fri, 5 Jul 2024 22:56:15 -0700
+Subject: [PATCH] [CMake] Use Clang to infer the target triple (#89425)
+
+When using Clang as a compiler, use Clang to normalize the triple that's
+used to construct path for runtime library build and install paths. This
+ensures that paths are consistent and avoids the issue where the build
+uses a different triple spelling.
+
+Differential Revision: https://reviews.llvm.org/D140925
+---
+ .../cmake/Modules/CompilerRTUtils.cmake       | 17 +++++++++++++----
+ runtimes/CMakeLists.txt                       | 19 +++++++++++++++++++
+ 3 files changed, 33 insertions(+), 5 deletions(-)
+
+diff --git a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+index 9c7fe64d0bd35d..cec7af929fb2b6 100644
+--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
++++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+@@ -368,14 +368,23 @@ macro(construct_compiler_rt_default_triple)
+           "Default triple for which compiler-rt runtimes will be built.")
+   endif()
+ 
+-  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
++  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+     set(option_prefix "")
+     if (CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+       set(option_prefix "/clang:")
+     endif()
+-    execute_process(COMMAND ${CMAKE_C_COMPILER} ${option_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple
+-                    OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
++    set(print_target_triple ${CMAKE_C_COMPILER} ${option_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple)
++    execute_process(COMMAND ${print_target_triple}
++      RESULT_VARIABLE result
++      OUTPUT_VARIABLE output
++      OUTPUT_STRIP_TRAILING_WHITESPACE)
++    if(result EQUAL 0)
++      set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${output})
++    else()
++      string(REPLACE ";" " " print_target_triple "${print_target_triple}")
++      # TODO(#97876): Report an error.
++      message(WARNING "Failed to execute `${print_target_triple}` to normalize target triple.")
++    endif()
+   endif()
+ 
+   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})


### PR DESCRIPTION
llvm-19 is not stable yet on arm

I chose two underlaying backports to make the actual fix in 0003 apply, and removed non needed parts. 

not sure where to put the PATCHES section? 