### PR TITLE
clang-crossdev-wrappers: destabilize slot 21

### DIFF
--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-21.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-21.ebuild
@@ -11,7 +11,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~arm64-macos ~x64-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~arm64-macos ~x64-macos"
 PROPERTIES="live"
 
 RDEPEND="


### PR DESCRIPTION
I just saw that it went straight to stable, maybe wait a bit for that? 