### PR TITLE
dev-lang/rust: add useflag to adjust llvm-tools

### DIFF
--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -10,6 +10,7 @@
 		<name>Rust Project</name>
 	</maintainer>
 	<use>
+		<flag name="llvm-tools">Install llvm-tools</flag>
 		<flag name="clippy">Install clippy, Rust code linter</flag>
 		<flag name="miri">Install miri, an interpreter for Rust's mid-level intermediate representation (requires USE=nightly)</flag>
 		<flag name="nightly">Enable nightly (UNSTABLE) features</flag>

--- a/dev-lang/rust/rust-1.89.0.ebuild
+++ b/dev-lang/rust/rust-1.89.0.ebuild
@@ -65,7 +65,7 @@ done
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
 
-IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind llvm-tools lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
 
 if [[ ${PV} = *9999* ]]; then
 	# These USE flags require nightly rust
@@ -507,6 +507,8 @@ src_configure() {
 		dist-src = false
 		remap-debuginfo = true
 		lld = $(usex system-llvm false $(toml_usex wasm))
+		# try to get rid of llvm-tools-preview
+		llvm-tools = $(toml_usex llvm-tools)
 		$(if use lto && tc-is-clang && ! tc-ld-is-mold; then
 			echo "use-lld = true"
 		fi)

--- a/dev-lang/rust/rust-1.90.0.ebuild
+++ b/dev-lang/rust/rust-1.90.0.ebuild
@@ -65,7 +65,7 @@ done
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
 
-IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind llvm-tools lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
 
 if [[ ${PV} = *9999* ]]; then
 	# These USE flags require nightly rust
@@ -511,6 +511,8 @@ src_configure() {
 		dist-src = false
 		remap-debuginfo = true
 		lld = $(usex system-llvm false $(toml_usex wasm))
+		# try to get rid of llvm-tools-preview
+		llvm-tools = $(toml_usex llvm-tools)
 		$(if use lto && tc-is-clang && ! tc-ld-is-mold; then
 			echo "use-lld = true"
 		fi)

--- a/dev-lang/rust/rust-1.91.0_beta20250921.ebuild
+++ b/dev-lang/rust/rust-1.91.0_beta20250921.ebuild
@@ -64,7 +64,7 @@ done
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
 
-IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind llvm-tools lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
 
 if [[ ${PV} = *9999* ]]; then
 	# These USE flags require nightly rust
@@ -510,6 +510,8 @@ src_configure() {
 		dist-src = false
 		remap-debuginfo = true
 		lld = $(usex system-llvm false $(toml_usex wasm))
+		# try to get rid of llvm-tools-preview
+		llvm-tools = $(toml_usex llvm-tools)
 		$(if use lto && tc-is-clang && ! tc-ld-is-mold; then
 			echo "use-lld = true"
 		fi)

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -76,7 +76,7 @@ done
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
 
-IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind llvm-tools lto rustfmt rust-analyzer rust-src +system-llvm test wasm sanitizers ${ALL_LLVM_TARGETS[*]}"
 
 if [[ ${PV} = *9999* ]]; then
 	# These USE flags require nightly rust
@@ -518,6 +518,8 @@ src_configure() {
 		dist-src = false
 		remap-debuginfo = true
 		lld = $(usex system-llvm false $(toml_usex wasm))
+		# try to get rid of llvm-tools-preview
+		llvm-tools = $(toml_usex llvm-tools)
 		$(if use lto && tc-is-clang && ! tc-ld-is-mold; then
 			echo "use-lld = true"
 		fi)


### PR DESCRIPTION
llvm-tools useflag to control the emerge of these files: 

/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llc
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-ar
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-as
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-dis
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-link
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-nm
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objcopy
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objdump
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-readobj
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-size
/usr/lib/rust/1.89.0/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-strip
