### PR TITLE
Remove old packages from README.md, improve WASI instructions, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,27 @@ Please follow the [official instruction](https://wiki.gentoo.org/wiki/Ebuild_rep
 
 ## How to compile WASI Sdk using crossdev
 
+(Note that some text here shows LLVM version 22, if you are building for 21 substitute that value where appropriate)
+
 1. Create `crossdev` overlay
+
+(Easiest with `eselect repository create crossdev`)
 
 Symlink cmake.eclass in this overlay to `crossdev`
 
 ```shell
-ln -s 12101111-overlay/eclass/cmake.eclass crossdev/eclass
+ln -s 12101111-overlay/eclass crossdev/eclass
 ```
 
 2. Create crossdev wrapper
 
 ```shell
-sudo crossdev -L -t wasm32-wasip1
+crossdev -L -t wasm32-wasip1
 ```
 
-This will failed with mseeage: error: Target architecture not supported by installed LLVM toolchain. It's Ok because gentoo don't have official wasm32-wasi support.
+This will fail with the message: `error: Target architecture not supported by installed LLVM toolchain.` This is expected as Gentoo doesn't have official wasm32-wasi support.
 
-Symlink llvm-runtimes in this overlay to `crossdev`
+Symlink llvm-runtimes in this overlay to `crossdev` (possible that `crossdev` will do some of this for you, likely first five lines)
 
 ```shell
 ln -s ../../12101111-overlay/sys-devel/clang-crossdev-wrappers crossdev/cross_llvm-wasm32-wasip1
@@ -38,7 +42,7 @@ ln -s ../../12101111-overlay/dev-libs/wasi-libc crossdev/cross_llvm-wasm32-wasip
 
 3. Edit configs
 
-Append those flags to `/etc/portage/env/cross_llvm-wasm32-wasip1/llvm.conf`
+Append these flags to `/etc/portage/env/cross_llvm-wasm32-wasip1/llvm.conf`:
 
 ```shell
 AS="wasm32-wasip1-as"
@@ -50,7 +54,7 @@ LDFLAGS=""
 RUSTFLAGS="-Ctarget-cpu=lime1 -Copt-level=s -Ccodegen-units=1"
 ```
 
-Append those flags to `/etc/portage/package.env/cross_llvm-wasm32-wasip1`
+Append these flags to `/etc/portage/package.env/cross_llvm-wasm32-wasip1`:
 
 ```shell
 cross_llvm-wasm32-wasip1/wasi-libc cross_llvm-wasm32-wasip1/wasi-libc.conf
@@ -58,12 +62,12 @@ cross_llvm-wasm32-wasip1/wasi-libc cross_llvm-wasm32-wasip1/llvm.conf
 cross_llvm-wasm32-wasip1/libcxxabi cross_llvm-wasm32-wasip1/libcxx.conf
 cross_llvm-wasm32-wasip1/libcxxabi cross_llvm-wasm32-wasip1/llvm.conf
 ```
-
+Then, to create `wasi-libc.conf`:
 ```shell
 cp /etc/portage/env/cross_llvm-wasm32-wasip1/{linux-headers.conf,wasi-libc.conf}
 ```
 
-Remove `@../gentoo-runtimes.cfg` in `/etc/clang/cross/wasm32-wasip1.cfg` and append those flags
+Remove `@../gentoo-runtimes.cfg` in `/etc/clang/cross/wasm32-wasip1.cfg` and append these flags:
 
 ```shell
 --sysroot=/usr/wasm32-wasip1
@@ -73,7 +77,7 @@ Remove `@../gentoo-runtimes.cfg` in `/etc/clang/cross/wasm32-wasip1.cfg` and app
 --unwindlib=none
 ```
 
-4. Install packages
+4. Install packages:
 
 ```shell
 emerge cross_llvm-wasm32-wasip1/clang-crossdev-wrappers
@@ -89,11 +93,13 @@ llvm-readelf -h /usr/lib/clang/22/lib/wasm32-unknown-wasip1/libclang_rt.builtins
 # should output nothing
 ```
 
+
+(this will need to be unmasked)
 ```shell
 emerge cross_llvm-wasm32-wasip1/wasi-libc
 ```
 
-Check wasi-libc is compiled correctly:
+Check wasi-libc is compiled correctly (wasmtime can be installed with `cargo` or in dev-util/wasm-tools):
 
 ```shell
 cat << EOF > /tmp/hello.c
@@ -107,7 +113,7 @@ wasm32-wasip1-cc /tmp/hello.c -Os -o /tmp/hello.wasm
 wasmtime /tmp/hello.wasm
 ```
 
-Install C++ std:
+Install C++ std (unmask for 21 or 22):
 
 ```shell
 emerge cross_llvm-wasm32-wasip1/libcxxabi
@@ -128,7 +134,7 @@ wasm32-wasip1-c++ /tmp/hello.cpp -fno-exceptions -Os -o /tmp/hello.wasm
 wasmtime /tmp/hello.wasm
 ```
 
-Install Rust std:
+Install Rust std (need at least Rust 1.94.1 for this):
 
 /etc/portage/package.accept_keywords/cross_llvm-wasm32-wasip1
 
@@ -185,56 +191,32 @@ priority = 1000
 - [app-doc/zeal](https://github.com/zealdocs/zeal): Live ebuild, use qtwebengine as backend.
 - [app-editors/vnote](https://github.com/tamlok/vnote): Vnote 2 and vnotex 3.
 - [app-editors/vscode](https://github.com/microsoft/vscode/): Build vscode from source code.
-- app-emulation/wine-staging: Add patch for wayland support from [collabora](https://gitlab.collabora.com/alf/wine/-/tree/wayland).
-- app-office/libreoffice: Fix for musl.
 - [app-text/goldendict](https://github.com/xiaoyifang/goldendict/): Live ebuild of xiaoyifang's fork, use qtwebengine as backend.
 - dev-java/openjdk: Fix for clang and musl.
-- [dev-java/openjdk-bin](https://www.azul.com/downloads/zulu-community/): Prebuilt OpenJDK for musl system by Zulu Community.
 - [dev-lang/deno](https://github.com/denoland/deno): A modern runtime for JavaScript and TypeScript.
 - [dev-lang/luajit](https://github.com/openresty/luajit2): OpenResty's fork of LuaJIT.
 - [dev-lang/rust](https://github.com/rust-lang/rust/): Add libcxx, profiler, sanitizers support. fix for musl system. add wasm32-wasi support.
 - [dev-libs/mimalloc](https://github.com/microsoft/mimalloc): Build static and object files.
 - [dev-libs/wasi-libc](https://github.com/WebAssembly/wasi-libc): Live ebuild for wasi-libc, used in rust support for wasm32-wasi.
-- [dev-qt/qt-creator](https://github.com/qt-creator/qt-creator/): Fix [dev-qt/qt-creator-6.0.0 - highlighter.h: fatal error: AbstractHighlighter: No such file or directory](https://bugs.gentoo.org/846947).
-- [dev-qt/qtwebengine](https://github.com/qt/qtwebengine): Allow build GN with CXXFLAGS and chromium patches for musl.
-- dev-qt/qtwebkit: Fix for musl. Keep for history reason.
 - [dev-util/electron](https://github.com/electron/electron/): Build Electron from source code. Fix for musl.
 - [dev-util/electron-bin](https://github.com/electron/electron/): Electron built by upstream for **glibc**.
-- [dev-util/ghidra](https://ghidra-sre.org/): Build native dependences from source code.
 - dev-util/mingw64-toolchain: ignore USE=-abi_x86_32 and build as multilib toolchain on musl.
-- [games-emulation/dosbox-x](https://github.com/joncampbell123/dosbox-x): Fix for musl.
-- [games-util/mangohud](https://github.com/flightlessmango/MangoHud): Build mangoapp.
-- gui-apps/swaylock-effects: Remove gcc version check.
+- [dev-util/cemu](https://cemu.info): Fix for musl, currently one minor version behind.
 - [gui-apps/waybar](https://github.com/Alexays/Waybar): Libcxx support.
 - [gui-apps/wob](https://github.com/francma/wob): Live ebuild.
-- kde-plasma/breeze: Breeze for non kwin wm.
-- media-video/ffmpeg: Fix for Apple Silicon.
-- net-fs/samba: Fix for musl.
-- [media-im/tencent-qq](https://im.qq.com/linuxqq/download.html): 腾讯QQ Linux官方客户端. Keep for history reason.
-- net-libs/webkit-gtk: Fix for musl.
-- [net-p2p/qbittorrent-enhanced](https://github.com/c0re100/qBittorrent-Enhanced-Edition): Fix for musl.  Keep for history reason.
 - sys-apps/busybox: Fix for clang.
-- sys-apps/kmscon: Keep for history reason.
-- [sys-apps/musl-locales](https://gitlab.com/rilian-la-te/musl-locales): `locale` for musl
 - sys-apps/systemd: systemd with musl patches from openembedded. Use with `12101111-overlay:clang/musl/<arch>/systemd` profile.
 - sys-boot/m1n1: First stage bootloader for Apple Silicon computer. Update the binary using sys-boot/m1n1/files/update-m1n1.
 - sys-boot/uboot-asahi: Second stage bootloader for Apple Silicon computer.
-- sys-cluster/k3s: Fix for arm.
 - [sys-devel/binutils](https://sourceware.org/binutils/): GNU binutils ebuild that can disable most component. Useful for llvm binutils users
-- sys-devel/elftoolchain: Keep for history reason because old version of elfutils can't compile using clang.
-- sys-devel/llvm: Build mlir and polly.
-- sys-fs/lvm2: Fix for clang.
-- sys-fs/xfsprogs: Fix for musl.
 - sys-fs/zfs: Fix systemd support for musl.
 - sys-libs/gcompat: gcompat with more symbol. Keep for history reason.
 - sys-libs/libexecinfo: `backtrace` from NetBSD.
 - sys-libs/musl: Fix for chromium's partation allocator. Change the default allocator to rpmalloc. Update some assembly code.
 - sys-libs/musl-legacy-compat. Some header files from voidlinux.
-- virtual/libelf: use with elftoolchain
-- virtual/man: use busybox man instead of man-db
+- virtual/fortran: `add llvm-core/flang`
 - [www-client/chromium](https://github.com/chromium/chromium/): Fix for musl.
 - www-client/firefox: Enable C++/Rust cross language LTO & PGO.
-- x11-apps/igt-gpu-tools: remove sys-libs/libunwind dependence because it conflict with llvm-libunwind.
 - x11-misc/rofi: ebuild of wayland fork
 
 ## License
@@ -246,9 +228,6 @@ The following ebuild are not a fork from Gentoo main tree or GURU Project:
 - `app-editors/vnote:2`: [jorgicio overlay](https://github.com/jorgicio/jorgicio-gentoo-overlay)
 - `app-editors/vscode`: this overlay
 - `dev-util/electron`: [electron overlay](https://github.com/elprans/electron-overlay)
-- `dev-util/ghidra`: [pentoo overlay](https://github.com/pentoo/pentoo-overlay)
-- `media-im/tencent-qq`: [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/)
-- `net-p2p/qbittorrent-enhanced`: [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/)
 - `sys-boot/m1n1`: this overlay
 - `sys-boot/uboot-asahi`: this overlay
 - `sys-libs/gcompat`: [lanodan overlay](https://hacktivis.me/git/overlay/)
@@ -259,4 +238,4 @@ All patch files are distributed under the same license of the corresponding pack
 
 The following patches are not a fork from Gentoo main tree, musl overlay or GURU Project
 
-- `www-client/chromium`, `dev-util/electron` and `dev-qt/qtwebengine`: Alpine Linux and Voidlinux
+- `www-client/chromium` and `dev-util/electron`: Alpine Linux and Voidlinux

--- a/llvm-runtimes/libgcc/libgcc-22.1.6.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-22.1.6.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux"
 IUSE="debug test"
 
 DEPEND="


### PR DESCRIPTION
Had a little trouble following some of the instructions in the README for the wasm cross-compilation setup, figured having them a little bit more clear would lead to less issues created about it (my issue was with cmake.eclass, as when the folder eclass does not exist, cmake.eclass gets linked to crossdev/eclass as a file rather than eclass/cmake.eclass.

I also went ahead and pruned some of the old, defunct entries in README.md, given that the packages no longer exist in the current state of the overlay.

In addition, `llvm-runtimes/libgcc/libgcc-22.1.6.ebuild` was not properly masked and was causing update issues for me (I haven't updated to LLVM 22 yet). I'm assuming this was unintentional given the other packages are masked for LLVM 22 (as is the upstream Gentoo overlay), but if it was intentional that change can of course be omitted.