### PR TITLE
llvm-runtimes/libcxx: forward fix for pr184373

### DIFF
--- a/llvm-runtimes/libcxx/files/0002-llvm-undo-part-of-194317.patch
+++ b/llvm-runtimes/libcxx/files/0002-llvm-undo-part-of-194317.patch
@@ -2,7 +2,7 @@ diff --git a/libcxx/include/__locale_dir/locale_base_api.h b/libcxx/include/__lo
 index e1e60e18fd7c..d1fb4cdbcd43 100644
 --- a/libcxx/include/__locale_dir/locale_base_api.h
 +++ b/libcxx/include/__locale_dir/locale_base_api.h
-@@ -132,7 +132,9 @@
+@@ -134,7 +134,9 @@
  //       (by providing global non-reserved names) and the new API. As we move individual platforms
  //       towards the new way of defining the locale base API, this should disappear since each platform
  //       will define those directly.

--- a/llvm-runtimes/libcxx/libcxx-23.1.0.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-23.1.0.ebuild
@@ -43,7 +43,10 @@ BDEPEND="
 	)
 "
 
-PATCHES=( "${FILESDIR}/llvm-undo-part-of-194317.patch" )
+PATCHES=( 
+	"${FILESDIR}/0001-fix-llvm-pr184373.patch"
+	"${FILESDIR}/0002-llvm-undo-part-of-194317.patch"
+)
 
 LLVM_COMPONENTS=(
 	runtimes libcxx{,abi} libc llvm/{cmake,utils} cmake


### PR DESCRIPTION
rename, and rebase new patch without fuzzing

the old patch is still needed if system libc is musl